### PR TITLE
Don't require '@' to ping player

### DIFF
--- a/src/main/java/dev/stashy/extrasounds/mixin/ChatSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/ChatSound.java
@@ -20,7 +20,7 @@ public class ChatSound
             return;
         String msg = message.getString();
         ClientPlayerEntity p = MinecraftClient.getInstance().player;
-        if (msg.contains("@" + p.getName().getString()) || msg.contains("@" + p.getDisplayName().getString()))
+        if (msg.contains(p.getName().getString()) || msg.contains(p.getDisplayName().getString()))
             ExtraSounds.playSound(ExtraSounds.config.chatMention);
         else
             ExtraSounds.playSound(ExtraSounds.config.chat);


### PR DESCRIPTION
Lots of minecraft users use IRC style mentions (its_notjack: Blah blah), and also the user's name may be mentioned by other messages, and it's probably still useful for them to get pinged when their name is mentioned in them.