### PR TITLE
Added lightweight config support using cloth config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,16 @@ repositories {
         name = "stashymane's repo"
         url = "https://repo.stashy.dev"
     }
+
+    maven {
+        name = "ClothConfig"
+        url "https://maven.shedaniel.me/"
+    }
+
+    maven {
+        name = "ModMenu"
+        url "https://maven.terraformersmc.com/"
+    }
 }
 
 dependencies {
@@ -33,6 +43,12 @@ dependencies {
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
     modImplementation include("net.devtech:arrp:0.5.1")
     modImplementation include("dev.stashy:sound-categories:${project.soundcategories_version}")
+
+    modApi("me.shedaniel.cloth:cloth-config-fabric:5.2.47") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
+
+    modImplementation "com.terraformersmc:modmenu:2.0.14"
 }
 
 processResources {

--- a/src/main/java/dev/stashy/extrasounds/ExtraSounds.java
+++ b/src/main/java/dev/stashy/extrasounds/ExtraSounds.java
@@ -3,6 +3,9 @@ package dev.stashy.extrasounds;
 import dev.stashy.extrasounds.debug.DebugUtils;
 import dev.stashy.extrasounds.mapping.SoundPackLoader;
 import dev.stashy.extrasounds.sounds.Sounds;
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import net.fabricmc.api.ClientModInitializer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.sound.PositionedSoundInstance;
@@ -16,6 +19,7 @@ import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import org.apache.logging.log4j.LogManager;
@@ -29,12 +33,17 @@ public class ExtraSounds implements ClientModInitializer
     private static final Random r = new Random();
     private static long lastPlayed = System.currentTimeMillis();
     private static final Logger LOGGER = LogManager.getLogger();
+    public static ExtraSoundsConfig config;
 
     @Override
     public void onInitializeClient()
     {
         SoundPackLoader.init();
         DebugUtils.init();
+
+        //InitialiseConfig
+        AutoConfig.register(ExtraSoundsConfig.class, JanksonConfigSerializer::new);
+        config = AutoConfig.getConfigHolder(ExtraSoundsConfig.class).getConfig();
     }
 
     public static void inventoryClick(Slot slot, ItemStack cursor, SlotActionType actionType)

--- a/src/main/java/dev/stashy/extrasounds/ExtraSoundsConfig.java
+++ b/src/main/java/dev/stashy/extrasounds/ExtraSoundsConfig.java
@@ -1,0 +1,18 @@
+package dev.stashy.extrasounds;
+
+import me.shedaniel.autoconfig.*;
+import me.shedaniel.autoconfig.annotation.*;
+
+@Config(name = "extrasounds")
+public class ExtraSoundsConfig implements ConfigData
+{
+    public boolean enableHotbarScrollSounds = true;
+    public boolean enableItemSounds = true;
+    public boolean enableDropSounds = true;
+    public boolean enableCreativeInventoryScrollSounds = true;
+    public boolean enableChatMessageSounds = true;
+    public boolean enableChatMentionSounds = true;
+    public boolean enableStatusEffectsSounds = true;
+    public boolean enableKeyboardTypingSounds = true;
+    public boolean enableInventoryOpeningSounds = true;
+}

--- a/src/main/java/dev/stashy/extrasounds/ExtraSoundsModMenuIntegration.java
+++ b/src/main/java/dev/stashy/extrasounds/ExtraSoundsModMenuIntegration.java
@@ -1,0 +1,19 @@
+package dev.stashy.extrasounds;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import me.shedaniel.autoconfig.AutoConfig;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public class ExtraSoundsModMenuIntegration implements ModMenuApi
+{
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory()
+    {
+        return parent -> AutoConfig.getConfigScreen(ExtraSoundsConfig.class, parent).get();
+    }
+
+}
+

--- a/src/main/java/dev/stashy/extrasounds/mixin/ChatSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/ChatSound.java
@@ -23,8 +23,17 @@ public class ChatSound
         String msg = message.getString();
         ClientPlayerEntity p = MinecraftClient.getInstance().player;
         if (msg.contains("@" + p.getName().getString()) || msg.contains("@" + p.getDisplayName().getString()))
-            ExtraSounds.playSound(Sounds.CHAT_MENTION, Mixers.CHAT);
-        else
+        {
+            if (ExtraSounds.config.enableChatMentionSounds)
+            {
+                ExtraSounds.playSound(Sounds.CHAT_MENTION, Mixers.CHAT);
+            }
+        }
+
+        else if (ExtraSounds.config.enableChatMessageSounds)
+        {
             ExtraSounds.playSound(Sounds.CHAT, Mixers.CHAT);
+        }
+
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/EffectMixin.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/EffectMixin.java
@@ -26,7 +26,7 @@ public abstract class EffectMixin extends AbstractClientPlayerEntity
     public boolean addStatusEffect(StatusEffectInstance effect, @Nullable Entity source)
     {
         var added = super.addStatusEffect(effect, source);
-        if (added && !hasEffect(effect.getEffectType()))
+        if (added && !hasEffect(effect.getEffectType()) && ExtraSounds.config.enableStatusEffectsSounds)
             ExtraSounds.playEffectSound(effect.getEffectType(), true);
         return added;
     }
@@ -34,7 +34,7 @@ public abstract class EffectMixin extends AbstractClientPlayerEntity
     @Override
     public void setStatusEffect(StatusEffectInstance effect, @Nullable Entity source)
     {
-        if (!hasEffect(effect.getEffectType()))
+        if (!hasEffect(effect.getEffectType()) && ExtraSounds.config.enableStatusEffectsSounds)
             ExtraSounds.playEffectSound(effect.getEffectType(), true);
         super.setStatusEffect(effect, source);
     }
@@ -42,14 +42,14 @@ public abstract class EffectMixin extends AbstractClientPlayerEntity
     @Override
     protected void onStatusEffectRemoved(StatusEffectInstance effect)
     {
-        if (hasEffect(effect.getEffectType())) ExtraSounds.playEffectSound(effect.getEffectType(), false);
+        if (hasEffect(effect.getEffectType()) && ExtraSounds.config.enableStatusEffectsSounds) ExtraSounds.playEffectSound(effect.getEffectType(), false);
         super.onStatusEffectRemoved(effect);
     }
 
     @Inject(at = @At("HEAD"), method = "removeStatusEffectInternal")
     public void removeStatusEffectInternal(StatusEffect type, CallbackInfoReturnable<StatusEffectInstance> cir)
     {
-        if (hasStatusEffect(type))
+        if (hasStatusEffect(type) && ExtraSounds.config.enableStatusEffectsSounds)
             ExtraSounds.playEffectSound(type, false);
     }
 

--- a/src/main/java/dev/stashy/extrasounds/mixin/HotbarScrollSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/HotbarScrollSound.java
@@ -15,6 +15,9 @@ public class HotbarScrollSound
     @Inject(at = @At("RETURN"), method = "scrollInHotbar")
     private void hotbarSound(CallbackInfo info)
     {
-        ExtraSounds.playSound(Sounds.HOTBAR_SCROLL, Mixers.INTERFACE);
+        if (ExtraSounds.config.enableHotbarScrollSounds)
+        {
+            ExtraSounds.playSound(Sounds.HOTBAR_SCROLL, Mixers.INTERFACE);
+        }
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/HotbarSlotSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/HotbarSlotSound.java
@@ -24,18 +24,24 @@ public class HotbarSlotSound
     @Inject(method = "handleInputEvents", at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, target = "Lnet/minecraft/entity/player/PlayerInventory;selectedSlot*:I"), locals = LocalCapture.CAPTURE_FAILSOFT)
     private void hotbarKeyboardSound(CallbackInfo info, int i)
     {
-        if (this.player != null && this.player.getInventory().selectedSlot != i)
+        if (this.player != null && this.player.getInventory().selectedSlot != i && ExtraSounds.config.enableHotbarScrollSounds)
             playScroll();
     }
 
     @Inject(method = "handleInputEvents", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SpectatorHud;selectSlot(I)V"))
     private void spectatorHotbarSound(CallbackInfo ci)
     {
-        playScroll();
+        if (ExtraSounds.config.enableHotbarScrollSounds)
+        {
+            playScroll();
+        }
     }
 
     private void playScroll()
     {
-        ExtraSounds.playSound(Sounds.HOTBAR_SCROLL, Mixers.INTERFACE, 0.95f);
+        if (ExtraSounds.config.enableHotbarScrollSounds)
+        {
+            ExtraSounds.playSound(Sounds.HOTBAR_SCROLL, Mixers.INTERFACE, 0.95f);
+        }
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/ItemPickSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/ItemPickSound.java
@@ -25,7 +25,7 @@ public class ItemPickSound
     })
     void pickSound(ItemStack stack, CallbackInfo ci)
     {
-        if (!player.getMainHandStack().getItem().equals(stack.getItem()))
+        if (!player.getMainHandStack().getItem().equals(stack.getItem()) && ExtraSounds.config.enableItemSounds)
             ExtraSounds.playItemSound(stack, true);
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/KeyboardTypingSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/KeyboardTypingSound.java
@@ -15,7 +15,7 @@ public class KeyboardTypingSound
     @Inject(at = @At("RETURN"), method = "charTyped")
     public void type(char chr, int modifiers, CallbackInfoReturnable<Boolean> cir)
     {
-        if (cir.getReturnValue())
+        if (cir.getReturnValue() && ExtraSounds.config.enableKeyboardTypingSounds)
             ExtraSounds.playSound(Sounds.KEYBOARD_TYPE, Mixers.CHAT);
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/inventory/CreativeInventoryClickSounds.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/inventory/CreativeInventoryClickSounds.java
@@ -52,18 +52,25 @@ public abstract class CreativeInventoryClickSounds
                     || actionType.equals(SlotActionType.QUICK_MOVE)
                     && slots != null && slots.parallelStream().noneMatch(Slot::hasStack))
                 return;
-            ExtraSounds.playSound(Sounds.ITEM_DELETE);
+            if (ExtraSounds.config.enableItemSounds)
+            {
+                ExtraSounds.playSound(Sounds.ITEM_DELETE);
+            }
             lastDeleteSound = System.currentTimeMillis();
         }
         else
+        if (ExtraSounds.config.enableItemSounds)
+        {
             ExtraSounds.inventoryClick(slot, handler.getCursorStack(),
-                                       actionType);
+                    actionType);
+        }
+
     }
 
     @Inject(at = @At("INVOKE"), method = "setSelectedTab")
     void tabChange(ItemGroup group, CallbackInfo ci)
     {
-        if (selectedTab != -1 && group.getIndex() != selectedTab)
+        if (selectedTab != -1 && group.getIndex() != selectedTab && ExtraSounds.config.enableItemSounds)
             ExtraSounds.playItemSound(group.getIcon(), true);
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/inventory/CreativeListScroll.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/inventory/CreativeListScroll.java
@@ -21,7 +21,7 @@ public class CreativeListScroll
     {
         long now = System.currentTimeMillis();
         long timeDiff = now - lastTime;
-        if (timeDiff > 20 && lastPos != position && !(lastPos != 1 && position == 0))
+        if (timeDiff > 20 && lastPos != position && !(lastPos != 1 && position == 0) && ExtraSounds.config.enableCreativeInventoryScrollSounds)
         {
             ExtraSounds.playSound(
                     e, Mixers.INTERFACE,

--- a/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryClickSounds.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryClickSounds.java
@@ -31,7 +31,7 @@ public abstract class InventoryClickSounds<T extends ScreenHandler> extends Scre
     @Inject(at = @At("INVOKE"), method = "onMouseClick(Lnet/minecraft/screen/slot/Slot;IILnet/minecraft/screen/slot/SlotActionType;)V")
     void click(Slot slot, int invSlot, int clickData, SlotActionType actionType, CallbackInfo ci)
     {
-        if (slot != null)
+        if (slot != null && ExtraSounds.config.enableItemSounds)
             ExtraSounds.inventoryClick(slot, handler.getCursorStack(), actionType);
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryDragSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryDragSound.java
@@ -25,7 +25,7 @@ public class InventoryDragSound
     @Inject(method = "mouseDragged", at = @At(value = "INVOKE", target = "Ljava/util/Set;add(Ljava/lang/Object;)Z"), locals = LocalCapture.CAPTURE_FAILSOFT)
     private void dragSound(double mouseX, double mouseY, int button, double deltaX, double deltaY, CallbackInfoReturnable<Boolean> cir, Slot slot)
     {
-        if (!cursorDragSlots.contains(slot) && cursorDragSlots.size() > 0)
+        if (!cursorDragSlots.contains(slot) && cursorDragSlots.size() > 0 && ExtraSounds.config.enableItemSounds)
             ExtraSounds.playSound(Sounds.ITEM_DRAG, Mixers.INTERFACE);
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryDropSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryDropSound.java
@@ -17,7 +17,7 @@ public class InventoryDropSound
     @Inject(at = @At("TAIL"), method = "dropItem(Lnet/minecraft/item/ItemStack;ZZ)Lnet/minecraft/entity/ItemEntity;")
     private void dropItem(ItemStack stack, boolean throwRandomly, boolean retainOwnership, CallbackInfoReturnable<ItemEntity> cir)
     {
-        if (retainOwnership && !stack.isEmpty())
+        if (retainOwnership && !stack.isEmpty() && ExtraSounds.config.enableDropSounds)
         {
             float range = 0.1f;
             float n = 1f + range *

--- a/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryScreenSounds.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryScreenSounds.java
@@ -15,12 +15,19 @@ public class InventoryScreenSounds
     @Inject(at = @At("HEAD"), method = "init")
     void open(CallbackInfo ci)
     {
-        ExtraSounds.playSound(Sounds.INVENTORY_OPEN, Mixers.INTERFACE);
+        if (ExtraSounds.config.enableInventoryOpeningSounds)
+        {
+            ExtraSounds.playSound(Sounds.INVENTORY_OPEN, Mixers.INTERFACE);
+        }
+
     }
 
     @Inject(at = @At("HEAD"), method = "onClose")
     void close(CallbackInfo ci)
     {
-        ExtraSounds.playSound(Sounds.INVENTORY_CLOSE, Mixers.INTERFACE);
+        if (ExtraSounds.config.enableInventoryOpeningSounds)
+        {
+            ExtraSounds.playSound(Sounds.INVENTORY_CLOSE, Mixers.INTERFACE);
+        }
     }
 }

--- a/src/main/resources/assets/extrasounds/lang/en_us.json
+++ b/src/main/resources/assets/extrasounds/lang/en_us.json
@@ -1,5 +1,15 @@
 {
   "soundCategory.interface": "User Interface",
   "soundCategory.chat": "Chat Messages",
-  "soundCategory.effects": "Effects/Potions"
+  "soundCategory.effects": "Effects/Potions",
+  "text.autoconfig.extrasounds.title": "Extra Sounds",
+  "text.autoconfig.extrasounds.option.enableHotbarScrollSounds": "Hotbar Scroll Sounds",
+  "text.autoconfig.extrasounds.option.enableItemSounds": "Item Sounds",
+  "text.autoconfig.extrasounds.option.enableDropSounds": "Drop Sounds",
+  "text.autoconfig.extrasounds.option.enableCreativeInventoryScrollSounds": "Inventory Scroll Sounds",
+  "text.autoconfig.extrasounds.option.enableChatMessageSounds": "Chat Message Sounds",
+  "text.autoconfig.extrasounds.option.enableChatMentionSounds": "Chat Mention Sounds",
+  "text.autoconfig.extrasounds.option.enableStatusEffectsSounds": "Status Effects Sounds",
+  "text.autoconfig.extrasounds.option.enableKeyboardTypingSounds": "Keyboard Typing Sounds",
+  "text.autoconfig.extrasounds.option.enableInventoryOpeningSounds": "Inventory Opening Sounds"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,9 @@
     ],
     "sound-categories": [
       "dev.stashy.extrasounds.Mixers"
+    ],
+    "modmenu": [
+      "dev.stashy.extrasounds.ExtraSoundsModMenuIntegration"
     ]
   },
   "mixins": [


### PR DESCRIPTION
I added a granular config for every single sound feature using Cloth Config.
I also added mod menu support which allows players to toggle each sound during runtime without any restarts.

The entire build filesize is only 7kbs bigger than before.
The Mod requires cloth config using this change though, I think. This should be no problem though as most other mods require it these days.