### PR TITLE
Added support for Minecraft 1.19.2 and 1.19.1, fixing issue #71. [※ BREAKING CHANGES]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.19
-yarn_mappings=1.19+build.2
-loader_version=0.14.7
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.1
+loader_version=0.14.8
 #Fabric api
-fabric_api_version=0.55.3+1.19
+fabric_api_version=0.58.6+1.19.2
 # Mod Properties
-mod_version=2.3.1+1.19
+mod_version=2.3.1+1.19.2-1.19.1
 maven_group=dev.stashy
 archives_base_name=extrasounds
 soundcategories_version=1.2.4+1.19

--- a/src/main/java/dev/stashy/extrasounds/mixin/ChatSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/ChatSound.java
@@ -5,18 +5,22 @@ import dev.stashy.extrasounds.sounds.SoundType;
 import dev.stashy.extrasounds.sounds.Sounds;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.ChatHud;
+import net.minecraft.client.gui.hud.MessageIndicator;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.network.message.MessageSignatureData;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import javax.annotation.Nullable;
+
 @Mixin(ChatHud.class)
 public class ChatSound
 {
-    @Inject(at = @At("RETURN"), method = "addMessage(Lnet/minecraft/text/Text;IIZ)V")
-    private void messageSound(Text message, int messageId, int timestamp, boolean refresh, CallbackInfo ci)
+    @Inject(at = @At("RETURN"), method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;ILnet/minecraft/client/gui/hud/MessageIndicator;Z)V")
+    private void messageSound(Text message, @Nullable MessageSignatureData signature, int ticks, @Nullable MessageIndicator indicator, boolean refresh, CallbackInfo ci)
     {
         if (MinecraftClient.getInstance().player == null || refresh)
             return;


### PR DESCRIPTION
## If you're just a normal user (non-developer) who just wants to use ExtraSounds on 1.19.2/1.19.1 right this instant…
**If you don't want to build ExtraSounds yourself, and you trust me / are comfortable running unofficial binaries from me**, here's a prebuilt jar that you can just drop into your `mods/` folder:

https://developer.akemi.ai/Minecraft/extrasounds-2.3.1+1.19.2-1.19.1~akemi-git-7a58d66.jar

---

Added support for Minecraft 1.19.2 and 1.19.1, fixing issue #71.

I actually made this fix a few… _weeks_ ago for private use but I may have uh… completely forgot to actually push and submit the PR. Oops. Better late than never though, I guess…?

---

**※ IMPORTANT:** Please note that this commit _completely_ breaks support for Minecraft 1.19 due to Yarn mapping changes!

For this reason, I think it would be a good idea to merge this PR into a completely new branch, as opposed to into the existing `1.19` branch, unless if you intend to drop support for 1.19 in the future.

And yes, issue #69 still occurs on 1.19.2 and 1.19.1. The issue appears to be some sort of mixin conflict happening in your SoundCategories library (I haven't taken a close look at it yet, will do so when I have more time.)

---

## Changes made:
* `gradle.properties`: Target Minecraft 1.19.2 in gradle.properties — this is still compatible with 1.19.1!
* `ChatSound.java`: Update method signature used for `pickup()` hook, as it is now completely different as of 1.19.1.