### PR TITLE
Port to MC1.19.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "fabric-loom" version "0.12-SNAPSHOT"
+    id "fabric-loom" version "1.0-SNAPSHOT"
     id "maven-publish"
     id "com.matthewprenger.cursegradle" version "1.4.0"
     id "com.modrinth.minotaur" version "2.2.0"
@@ -22,7 +22,7 @@ repositories {
     }
     maven {
         name = "stashymane's repo"
-        url = "https://repo.stashy.dev"
+        url = "https://repo.stashy.dev/releases"
     }
 }
 
@@ -32,7 +32,8 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
-    modImplementation include("net.devtech:arrp:0.6.2")
+    modImplementation include("net.devtech:arrp:${project.arrp_version}")
+    // TODO: set the correct version of SoundCategories
     modImplementation include("dev.stashy:sound-categories:${project.soundcategories_version}")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,14 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.19.2
-yarn_mappings=1.19.2+build.1
-loader_version=0.14.8
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.5
+loader_version=0.14.12
 #Fabric api
-fabric_api_version=0.58.6+1.19.2
+fabric_api_version=0.71.0+1.19.3
 # Mod Properties
-mod_version=2.3.1+1.19.2-1.19.1
+mod_version=2.3.1+1.19.3
 maven_group=dev.stashy
 archives_base_name=extrasounds
+arrp_version=0.6.7
 soundcategories_version=1.2.4+1.19

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/stashy/extrasounds/SoundManager.java
+++ b/src/main/java/dev/stashy/extrasounds/SoundManager.java
@@ -8,11 +8,11 @@ import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.sound.SoundInstance;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.registry.Registry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,7 +23,7 @@ public class SoundManager
 
     public static void playSound(ItemStack stack, SoundType type)
     {
-        var itemId = Registry.ITEM.getId(stack.getItem());
+        var itemId = Registries.ITEM.getId(stack.getItem());
         String idString = ExtraSounds.getClickId(itemId, type);
         if (!Identifier.isValid(idString))
         {
@@ -32,7 +32,7 @@ public class SoundManager
         }
 
         Identifier id = Identifier.tryParse(idString);
-        Registry.SOUND_EVENT.getOrEmpty(id).ifPresentOrElse(
+        Registries.SOUND_EVENT.getOrEmpty(id).ifPresentOrElse(
                 (snd) -> playSound(snd, type),
                 () -> LOGGER.error("Sound cannot be found in registry: " + id));
     }

--- a/src/main/java/dev/stashy/extrasounds/mapping/SoundDefinition.java
+++ b/src/main/java/dev/stashy/extrasounds/mapping/SoundDefinition.java
@@ -1,8 +1,7 @@
 package dev.stashy.extrasounds.mapping;
 
 import net.minecraft.client.sound.SoundEntry;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class SoundDefinition
 {
@@ -15,19 +14,19 @@ public class SoundDefinition
         this(sound, null, null);
     }
 
-    public SoundDefinition(@Nonnull SoundEntry pickup, SoundEntry place, SoundEntry hotbar)
+    public SoundDefinition(@NotNull SoundEntry pickup, SoundEntry place, SoundEntry hotbar)
     {
         this.pickup = pickup;
         this.place = place;
         this.hotbar = hotbar;
     }
 
-    public static SoundDefinition of(@Nonnull SoundEntry pickup, SoundEntry place, SoundEntry hotbar)
+    public static SoundDefinition of(@NotNull SoundEntry pickup, SoundEntry place, SoundEntry hotbar)
     {
         return new SoundDefinition(pickup, place, hotbar);
     }
 
-    public static SoundDefinition of(@Nonnull SoundEntry sound)
+    public static SoundDefinition of(@NotNull SoundEntry sound)
     {
         return new SoundDefinition(sound);
     }

--- a/src/main/java/dev/stashy/extrasounds/mapping/SoundPackLoader.java
+++ b/src/main/java/dev/stashy/extrasounds/mapping/SoundPackLoader.java
@@ -15,11 +15,12 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.sound.Sound;
 import net.minecraft.client.sound.SoundEntry;
 import net.minecraft.item.BlockItem;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
-import net.minecraft.util.registry.Registry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -68,8 +69,8 @@ public class SoundPackLoader
 
     private static Map<String, SoundEntry> processSounds()
     {
-        return Registry.ITEM.stream().flatMap(item -> {
-            var itemId = Registry.ITEM.getId(item);
+        return Registries.ITEM.stream().flatMap(item -> {
+            var itemId = Registries.ITEM.getId(item);
             SoundDefinition def = new SoundDefinition(Sounds.aliased(Sounds.ITEM_PICK));
 
             if (mappers.containsKey(itemId.getNamespace()))
@@ -101,9 +102,9 @@ public class SoundPackLoader
     private static SoundEvent registerIfNotExists(Identifier itemId, SoundType type)
     {
         var soundId = new Identifier(ExtraSounds.MODID, ExtraSounds.getClickId(itemId, type, false));
-        var event = new SoundEvent(soundId);
-        if (!Registry.SOUND_EVENT.containsId(soundId))
-            Registry.register(Registry.SOUND_EVENT, soundId, event);
+        var event = SoundEvent.of(soundId);
+        if (!Registries.SOUND_EVENT.containsId(soundId))
+            Registry.register(Registries.SOUND_EVENT, soundId, event);
         return event;
     }
 
@@ -119,8 +120,8 @@ public class SoundPackLoader
                     var jsonObj = JsonParser.parseString(cache).getAsJsonObject();
                     jsonObj.keySet().forEach((it) -> {
                         var identifier = new Identifier(ExtraSounds.MODID, it);
-                        if (!Registry.SOUND_EVENT.containsId(identifier))
-                            Registry.register(Registry.SOUND_EVENT, identifier, new SoundEvent(identifier));
+                        if (!Registries.SOUND_EVENT.containsId(identifier))
+                            Registry.register(Registries.SOUND_EVENT, identifier, SoundEvent.of(identifier));
                     });
                     return cache;
                 }
@@ -161,7 +162,7 @@ public class SoundPackLoader
         {
             var versionInfos = SoundPackLoader.mappers
                     .values().stream().map(it -> getModVersion(it.modId())).toArray(String[]::new);
-            return new CacheInfo(CACHE_VERSION, Registry.ITEM.size(), versionInfos);
+            return new CacheInfo(CACHE_VERSION, Registries.ITEM.size(), versionInfos);
         }
 
         public static CacheInfo fromString(String s)

--- a/src/main/java/dev/stashy/extrasounds/mapping/VanillaGenerator.java
+++ b/src/main/java/dev/stashy/extrasounds/mapping/VanillaGenerator.java
@@ -7,8 +7,8 @@ import net.minecraft.block.*;
 import net.minecraft.client.sound.Sound;
 import net.minecraft.client.sound.SoundEntry;
 import net.minecraft.item.*;
+import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,7 +22,7 @@ public class VanillaGenerator
     public static final Map<Class<? extends Item>, Function<Item, SoundEntry>> map = new HashMap<>();
 
     public static SoundGenerator generator = SoundGenerator.of("minecraft", ExtraSounds.MODID, item -> {
-        Identifier id = Registry.ITEM.getId(item);
+        Identifier id = Registries.ITEM.getId(item);
         Class cls = item.getClass();
         while (!map.containsKey(cls) && cls.getSuperclass() != null && Item.class.isAssignableFrom(cls.getSuperclass()))
             cls = cls.getSuperclass();

--- a/src/main/java/dev/stashy/extrasounds/mixin/ChatSound.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/ChatSound.java
@@ -9,12 +9,11 @@ import net.minecraft.client.gui.hud.MessageIndicator;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.network.message.MessageSignatureData;
 import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import javax.annotation.Nullable;
 
 @Mixin(ChatHud.class)
 public class ChatSound

--- a/src/main/java/dev/stashy/extrasounds/mixin/EffectMixin.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/EffectMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
-import net.minecraft.network.encryption.PlayerPublicKey;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -18,9 +17,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(ClientPlayerEntity.class)
 public abstract class EffectMixin extends AbstractClientPlayerEntity
 {
-    public EffectMixin(ClientWorld world, GameProfile profile, @Nullable PlayerPublicKey publicKey)
+    public EffectMixin(ClientWorld world, GameProfile profile)
     {
-        super(world, profile, publicKey);
+        super(world, profile);
     }
 
     @Override

--- a/src/main/java/dev/stashy/extrasounds/mixin/inventory/CreativeInventoryClickSounds.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/inventory/CreativeInventoryClickSounds.java
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemGroups;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
@@ -29,7 +30,7 @@ public abstract class CreativeInventoryClickSounds
 {
 
     @Shadow
-    private static int selectedTab;
+    private static ItemGroup selectedTab;
 
     @Shadow
     @Nullable
@@ -70,7 +71,7 @@ public abstract class CreativeInventoryClickSounds
     @Inject(at = @At("HEAD"), method = "setSelectedTab")
     void tabChange(ItemGroup group, CallbackInfo ci)
     {
-        if (selectedTab != -1 && group.getIndex() != selectedTab)
+        if (selectedTab != ItemGroups.getDefaultTab() && group != selectedTab)
             SoundManager.playSound(group.getIcon(), SoundType.PICKUP);
     }
 }
@@ -78,7 +79,7 @@ public abstract class CreativeInventoryClickSounds
 @Mixin(CreativeInventoryScreen.CreativeScreenHandler.class)
 class CreativeScreenHandlerSounds
 {
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/slot/Slot;setStack(Lnet/minecraft/item/ItemStack;)V"), method = "transferSlot")
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/slot/Slot;setStack(Lnet/minecraft/item/ItemStack;)V"), method = "quickMove")
     void transfer(PlayerEntity player, int index, CallbackInfoReturnable<ItemStack> cir)
     {
         SoundManager.playSound(Sounds.ITEM_DELETE, SoundType.PICKUP);

--- a/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryClickSounds.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/inventory/InventoryClickSounds.java
@@ -54,7 +54,7 @@ public abstract class InventoryClickSounds
             ExtraSounds.inventoryClick(slots.get(slotIndex), getCursorStack(), actionType);
     }
 
-    @Inject(at = @At(value = "INVOKE_ASSIGN", ordinal = 0, target = "Lnet/minecraft/screen/ScreenHandler;transferSlot(Lnet/minecraft/entity/player/PlayerEntity;I)Lnet/minecraft/item/ItemStack;"), method = "internalOnSlotClick", locals = LocalCapture.CAPTURE_FAILSOFT)
+    @Inject(at = @At(value = "INVOKE_ASSIGN", ordinal = 0, target = "Lnet/minecraft/screen/ScreenHandler;quickMove(Lnet/minecraft/entity/player/PlayerEntity;I)Lnet/minecraft/item/ItemStack;"), method = "internalOnSlotClick", locals = LocalCapture.CAPTURE_FAILSOFT)
     void transfer(int slotIndex, int button, SlotActionType actionType, PlayerEntity player, CallbackInfo ci, PlayerInventory playerInventory, ClickType clickType, Slot slot, ItemStack itemStack)
     {
         if (!itemStack.isEmpty())

--- a/src/main/java/dev/stashy/extrasounds/sounds/SoundRegistry.java
+++ b/src/main/java/dev/stashy/extrasounds/sounds/SoundRegistry.java
@@ -1,18 +1,19 @@
 package dev.stashy.extrasounds.sounds;
 
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import org.apache.logging.log4j.LogManager;
 
 public class SoundRegistry
 {
     static SoundEvent register(Identifier id)
     {
-        var e = new SoundEvent(id);
+        var e = SoundEvent.of(id);
         try
         {
-            Registry.register(Registry.SOUND_EVENT, id, e);
+            Registry.register(Registries.SOUND_EVENT, id, e);
         }
         catch (IllegalStateException exception)
         {


### PR DESCRIPTION
awaiting for a new release of SoundCategories...

----

**Changes**

* update dependencies
  - `gradle.properties`
    + yarn mappings 1.19.3+build.5
    + fabric api 0.71.0
    + fabric loader 0.14.12
    + ARRP 0.6.7
  - `build.gradle`
    + fabric loom 1.0-SNAPSHOT
  - `gradle-wrapper.properties`
    + Gradle 7.6

* class usage has changed
  - `new SoundEvent` -> `SoundEvent.of`

* mixin method signature has changed
  - affected classes: `inventory.InventoryClickSounds`, `inventory.CreativeScreenHandlerSounds`
    + `net.minecraft.screen.ScreenHandler#transferSlot` -> `quickMove`
  - affected class: `EffectMixin`
    + `ClientPlayerEntity#<init>(ClientWorld, GameProfile, PlayerPublicKey)` -> `<init>(ClientWorld, GameProfile)`

* mixin field type has changed
  - affected class: `inventory.CreativeInventoryClickSounds`
    + `net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen::selectedTab`: `int` -> `ItemGroup`

* import statement has changed
  - `javax.annotation.*` -> `org.jetbrains.annotations.*`
  - `net.minecraft.util.registry.Registry` -> `net.minecraft.registry.*`